### PR TITLE
docu: add more info to gitlab sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,12 @@ Upload success
 
 ### GitLab Snippets
 You must obtain access token.
-Go https://gitlab.com/profile/personal_access_tokens and create access token.
+Go https://gitlab.com/-/profile/personal_access_tokens and create access token.
 Set that to `access_token` in `[GitLab]` or use an environment variable with the name `$PET_GITLAB_ACCESS_TOKEN`..
+
+You also have to configure the `url` under `[GitLab]`, so pet knows which endpoint to access. You would use `url = "https://gitlab.com"`unless you have another instance of Gitlab.
+
+At last, switch the `backend` under `[General]` to `backend = "gitlab"`.
 
 After setting, you can upload snippets to GitLab Snippets.
 If `id` is not set, new snippet will be created.


### PR DESCRIPTION
- correct url for access tokens
- add additional config info